### PR TITLE
create PR that needs changelog entry

### DIFF
--- a/.github/workflows/write-status-changelog-instructions.yml
+++ b/.github/workflows/write-status-changelog-instructions.yml
@@ -25,7 +25,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             github.rest.repos.createCommitStatus({
-              sha: context.payload.pull_request.head.sha,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.workflow_run.head_sha,
               state: "error",
               context: "Click here for changelog instructions.",
               description: "Missing or malconfigured changelog.",

--- a/.github/workflows/write-status-changelog-instructions.yml
+++ b/.github/workflows/write-status-changelog-instructions.yml
@@ -1,0 +1,33 @@
+name: Changelog Instructions Status
+# Writes a status with a link to the Changelog Instructions if Check Changelog fails.
+# See:
+# https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md
+
+permissions:
+  statuses: write
+
+on:
+  workflow_run:
+    workflows: ["Check Changelog"]
+    types:
+      - completed
+
+jobs:
+  display_link_to_changelog_instructions:
+    name: TEST A reviewer will let you know if it is required or can be bypassed TEST
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Write status with link to changelog instructions
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.repos.createCommitStatus({
+              sha: context.payload.pull_request.head.sha,
+              state: "error",
+              context: "Click here for changelog instructions.",
+              description: "Missing or malconfigured changelog.",
+              target_url: "https://github.com/scikit-learn/scikit-learn/blob/main/doc/whats_new/upcoming_changes/README.md"
+            })

--- a/doc/whats_new/upcoming_changes/sklearn.decomposition/0.fix.rst
+++ b/doc/whats_new/upcoming_changes/sklearn.decomposition/0.fix.rst
@@ -1,0 +1,2 @@
+- Misnamed Changelog Entry.
+  https://github.com/scientific-python/action-towncrier-changelog should fail.

--- a/sklearn/decomposition/tests/test_pca.py
+++ b/sklearn/decomposition/tests/test_pca.py
@@ -1153,3 +1153,7 @@ def test_array_api_error_and_warnings_on_unsupported_params():
     with pytest.warns(UserWarning, match=expected_msg):
         with config_context(array_api_dispatch=True):
             pca.fit(iris_xp)
+
+
+def test_touch_test_file_so_changelog_entry_is_needed():
+    pass


### PR DESCRIPTION
Test PR

itinary:
1. only edit test file (without adding Changelog entry) --> new status shows as "error"
2. add a misnamed Changelog entry --> new status shows as "error"
3. set "No Changelog Needed" label --> new status shows as "success"
4. remove "No Changelog Needed" label --> new status shows as "error"